### PR TITLE
Remove .ipynb_checkpoints from Git version control

### DIFF
--- a/.ipynb_checkpoints/Untitled-checkpoint.ipynb
+++ b/.ipynb_checkpoints/Untitled-checkpoint.ipynb
@@ -1,6 +1,0 @@
-{
- "cells": [],
- "metadata": {},
- "nbformat": 4,
- "nbformat_minor": 2
-}


### PR DESCRIPTION
# Changed log

- Removing the `.ipynb_checkpoints` directory because the Git can do the same work.